### PR TITLE
Fix docstring typo in kubernetes-helm-template

### DIFF
--- a/kubernetes-helm.el
+++ b/kubernetes-helm.el
@@ -118,7 +118,7 @@ NAMESPACE is the namespace."
 
 ;;;###autoload
 (defun kubernetes-helm-template (directory)
-  "Render chat template locally.
+  "Render chart template locally.
 
 DIRECTORY is the location of the chart."
   (interactive "DChart: ")


### PR DESCRIPTION
Hi, just started using this package and noticed a small typo